### PR TITLE
Add support to use the file as an argument

### DIFF
--- a/forca_v1.py
+++ b/forca_v1.py
@@ -1,7 +1,8 @@
 # Hangman Game (Jogo da Forca)
 
 # Import
-import random
+import random, argparse, sys
+
 
 # Board (tabuleiro)
 board = ['''
@@ -127,10 +128,16 @@ class Hangman:
 
 # Função para ler uma palavra de forma aleatória do banco de palavras
 def rand_word():
-    with open("palavras.txt", "rt") as f:
-        bank = f.readlines()
-    return bank[random.randint(0, len(bank))].strip()
-
+    parser = argparse.ArgumentParser(description = 'Jogo da Forca')
+    parser.add_argument('--path', default='palavras.txt', help='')
+    args = parser.parse_args()
+    try:    
+        with open(args.path, "rt") as f:
+            bank = f.readlines()
+        return bank[random.randint(0, len(bank))].strip()
+    except FileNotFoundError: 
+       print(f'Arquivo {args.path} não encontrado')
+       sys.exit(1)
 
 # Função Main - Execução do Programa
 def main():


### PR DESCRIPTION
It will allow anyone to use their own database file without change the current one.
Eg.: To use the dictionary in a unix os you can do

```bash
python forca_v1.py --path=/usr/share/dict/words
```